### PR TITLE
Add version to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   api:
     image: node:17


### PR DESCRIPTION
Hey @kylecoberly 👋  ☕ 

I was getting the following error trying to run this repo locally:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'api'
```
Currently running Docker version 19.03.2 and docker-compose version 1.24.1 on my machine. Maybe it's not needed for more recent versions, but this seems to fix the error for me. 🤓 

Opening this PR in case it helps (but won't hurt my feelings if you decide to just close it).